### PR TITLE
feat(appbar): generate random titles

### DIFF
--- a/app/components/appbar-global.jsx
+++ b/app/components/appbar-global.jsx
@@ -1,7 +1,26 @@
 "use client";
 import { AppBar, Toolbar, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
 
-export default function AppBarGlobal() {
+const AppBarGlobal = () => {
+    const messages = [
+        "You're the D&Definition of awesome!",
+        "Let's D&Dive into the adventure!",
+        "Ready to D&Dare greatly today?",
+        "Don't worry, we've got this D&Down to a science.",
+        "No D&Doubt, you're going to crush this campaign!",
+        "Let's D&Dazzle them with your skills!",
+        "You're the D&Dream team every DM needs.",
+        "It's time to D&Dedicate yourself to epic storytelling!",
+        "You've got the D&Drive to defeat any dragon!",
+    ];
+    const [randomMessage, setRandomMessage] = useState("");
+    useEffect(() => {
+        const getRandomMessage = () => {
+            return messages[Math.floor(Math.random() * messages.length)];
+        };
+        setRandomMessage(getRandomMessage());
+    }, []);
     return (
         <AppBar position="static">
         <Toolbar
@@ -12,9 +31,10 @@ export default function AppBarGlobal() {
                 component="div"
                 fontFamily={"Georgia"}
             >
-            Just D&Deal With It
+            {randomMessage}
             </Typography>
         </Toolbar>
         </AppBar>
     );
     }
+export default AppBarGlobal;


### PR DESCRIPTION
## What?
Now the title is randomly selected from a collection of messages

## Why?
To keep our application dinamic and favor creativity among players

## How?
I used State and Effect from React to modify the appbar so it chooses a different message every time.

## Testing?
I ran the app and refreshed it several times to verify that the title does change randomly

## Screenshots
![image](https://github.com/user-attachments/assets/525c0469-139d-48b6-90c6-e9c6230e9ebe)
![image](https://github.com/user-attachments/assets/86f048e0-5940-4052-82e3-d622f1abf293)
![image](https://github.com/user-attachments/assets/5d4a1994-7738-44a8-baab-f7da39832837)

## Anything Else?
This feature could be connected to a database to get the messages from there