### PR TITLE
feat(components): added global alerts for snackbars

### DIFF
--- a/app/components/alerts.jsx
+++ b/app/components/alerts.jsx
@@ -1,0 +1,23 @@
+import { Alert, Snackbar } from "@mui/material";
+
+// This component shows an alert message
+export default function Alerts({ open, setOpen, alert, setAlert }) {
+  
+  // Function to close the alert
+  const handleClose = () => {
+    setOpen(false); // Close the alert
+  };
+
+  return (
+    <Snackbar
+      open={open} // Show or hide the alert
+      autoHideDuration={2000} // The alert will disappear after 2 seconds
+      onClose={handleClose} // Close the alert when needed
+      anchorOrigin={{ vertical: "bottom", horizontal: "center" }} // Position the alert at the bottom center of the screen
+    >
+      <Alert onClose={handleClose} severity={alert.severity} variant="filled">
+        {alert.message} {/* Show the alert message */}
+      </Alert>
+    </Snackbar>
+  );
+}


### PR DESCRIPTION
### What?
- Added a reusable `Alerts` component in `alerts.jsx` inside the `components` folder to display snackbars (alerts) across the project.

### Why?
- To provide a consistent and easy way to show alert messages (snackbars) throughout the application.
- To give users feedback with customizable messages and severity levels.

### How?
- Imported `Alert` and `Snackbar` components from Material UI.
- Created an `Alerts` component that takes `open`, `setOpen`, `alert`, and `setAlert` as props.
- Used `Snackbar` to display the alert and set auto-hide duration (2 seconds).
- Positioned the alert at the bottom center of the screen and used `Alert` to show the message with the specified severity and style.

### Testing?
- Tested the component by triggering alerts with different severity levels and checking that they display correctly and disappear after the set duration.

### Anything Else?
- Now the alert system is centralized, making it easy to show notifications across the project with a consistent style and behavior.