### PR TITLE
feat(layout): added theme button

### DIFF
--- a/app/components/theme-button.jsx
+++ b/app/components/theme-button.jsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React from 'react';
+import { IconButton } from '@mui/material';
+import WbSunnyIcon from '@mui/icons-material/WbSunny';
+import NightsStayIcon from '@mui/icons-material/NightsStay';
+import { useThemeToggle } from '../layout';
+
+const ThemeButton = () => {
+    const { toggleTheme, mode } = useThemeToggle();
+
+    return (
+        <IconButton
+            onClick={toggleTheme}
+            sx={{
+                position: 'fixed',
+                bottom: 16,
+                right: 16,
+                bgcolor: 'background.paper',
+                boxShadow: 3,
+                zIndex: 1000,
+            }}
+        >
+            {mode === 'dark' ? <WbSunnyIcon /> : <NightsStayIcon />}
+        </IconButton>
+    );
+};
+
+export default ThemeButton;

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,35 +1,56 @@
+"use client";
+
+import React, { createContext, useContext, useMemo, useState } from 'react';
 import { CssBaseline, ThemeProvider } from "@mui/material";
 import localFont from "next/font/local";
-import { theme } from "./styles/global-theme";
+import { darkTheme, lightTheme } from "./styles/global-theme";
 import AppBarGlobal from "./components/appbar-global";
+import ThemeButton from "./components/theme-button";
+import Head from 'next/head';
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
   variable: "--font-geist-sans",
   weight: "100 900",
 });
+
 const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
   variable: "--font-geist-mono",
   weight: "100 900",
 });
 
-export const metadata = {
-  title: "DND",
-  description: "DND",
-};
+// Crear el contexto para el tema
+const ThemeToggleContext = createContext();
+
+export const useThemeToggle = () => useContext(ThemeToggleContext);
 
 export default function RootLayout({ children }) {
+  const [mode, setMode] = useState('dark');
+
+  const theme = useMemo(() => (mode === 'dark' ? darkTheme : lightTheme), [mode]);
+
+  const toggleTheme = () => {
+    setMode((prevMode) => (prevMode === 'dark' ? 'light' : 'dark'));
+  };
+
   return (
     <html lang="en">
+      <Head>
+        <title>DND</title>
+        <meta name="description" content="DND" />
+      </Head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <ThemeProvider theme={theme}>
-          <CssBaseline />
-          <AppBarGlobal />
-          {children}
-        </ThemeProvider>
+        <ThemeToggleContext.Provider value={{ toggleTheme, mode }}>
+          <ThemeProvider theme={theme}>
+            <CssBaseline />
+            <AppBarGlobal />
+            <ThemeButton />
+            {children}
+          </ThemeProvider>
+        </ThemeToggleContext.Provider>
       </body>
     </html>
   );

--- a/app/styles/global-theme.jsx
+++ b/app/styles/global-theme.jsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { createTheme } from "@mui/material";
+import { createTheme } from '@mui/material/styles';
 
-export const theme = createTheme({
+// Definición de temas
+const lightTheme = createTheme({
   palette: {
-    mode: 'dark',
+    mode: "light",
     primary: {
       main: '#f939ff',
     },
@@ -12,8 +13,24 @@ export const theme = createTheme({
       main: '#fb2e2e',
     },
   },
-
   typography: {
     fontFamily: "Arial, sans-serif",
   },
 });
+
+const darkTheme = createTheme({
+  palette: {
+    mode: "dark",
+    primary: {
+      main: '#f939ff',
+    },
+    secondary: {
+      main: '#fb2e2e',
+    },
+  },
+  typography: {
+    fontFamily: "Arial, sans-serif",
+  },
+});
+
+export { lightTheme, darkTheme };


### PR DESCRIPTION
## What?
- Create and display a "change theme" button

## Why?
- Because is an enhances UX

## How?
- Adding the component theme-button
- Modifying the layout to receive and process the new button input
- Modifying the global-theme to return two themes

## Testing?
- Run the app and press the button!

## Screenshots (optional)
![image](https://github.com/user-attachments/assets/088ce0c8-ed49-4195-8707-d2e6278f88db)
![image](https://github.com/user-attachments/assets/e6d54ca9-fc07-4bc0-9c6b-5e1af89f7d57)
![image](https://github.com/user-attachments/assets/d49ecb97-7012-46c1-80e3-3181f41c3991)
![image](https://github.com/user-attachments/assets/beba7eb2-f089-4b8e-b30c-fd640c4ba6ed)