### PR TITLE
feat(npc): added npc page and dialog

### DIFF
--- a/app/npc/components/npc-dialog.jsx
+++ b/app/npc/components/npc-dialog.jsx
@@ -1,0 +1,143 @@
+import {
+  Dialog,
+  TextField,
+  DialogContent,
+  DialogTitle,
+  DialogActions,
+  Button,
+} from "@mui/material";
+import axios from "axios";
+
+// This component handles showing the dialog for adding or editing a npc
+export default function NpcDialog({
+  open,
+  setOpen,
+  npcData,
+  setNpc,
+  action,
+  rows,
+  setRows,
+  setAlert,
+  setOpenAlert,
+}) {
+  
+  // Close the dialog when the user clicks cancel or closes it
+  const handleCloseDialog = () => {
+    setOpen(false); // Close the dialog
+  };
+
+  // Save the npc data based on whether it's an "add" or "edit" action
+  const saveNpc = async () => {
+    if (action == "add") { // If the action is "add"
+      try {
+        const response = await axios.post("http://127.0.0.1:5000/api/v1/npcs", npcData); // Send data to the server to add the npc
+        setRows([...rows, response.data]); // Add the new npc to the rows
+        setAlert({
+          message: "Npc added successfully", // Success message
+          severity: "success", // Set the message severity as success
+        });
+      } catch (error) {
+        console.error("Error adding npc: ", error);
+        setAlert({
+          message: "Failed to add NPC", // Error message
+          severity: "error", // Set the message severity as error
+        });
+      }
+      setOpenAlert(true); // Show the alert
+
+    } else if (action === "edit") { // If the action is "edit"
+      try {
+        const response = await axios.put(`http://127.0.0.1:5000/api/v1/npcs/${npcData._id}`, npcData); // Update npc on the server
+        setRows(rows.map((row) => (row._id === npcData._id ? response.data : row))); // Update the npc in the rows list
+        setAlert({
+          message: "Npc updated successfully", // Success message
+          severity: "success", // Set the message severity as success
+        });
+      } catch (error) {
+        setAlert({
+          message: "Failed to update npc", // Error message
+          severity: "error", // Set the message severity as error
+        });
+      }
+      setOpenAlert(true); // Show the alert
+    }
+    handleCloseDialog(); // Close the dialog after saving
+  };
+
+  // Handle changes in the input fields and update the npcData state
+  const handleChange = (event) => {
+    setNpc({
+      ...npcData, // Keep the current npc data and update only the changed field
+      [event.target.name]: event.target.value, // Set the new value for the specific field
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={handleCloseDialog}> {/* Show the dialog */}
+      <DialogTitle alignSelf={"center"}> {action === "add" ? "Add NPC" : "Edit NPC"} </DialogTitle>
+      <DialogContent>
+        {/* Input fields for npc details */}
+        <TextField
+          margin="dense"
+          size="small"
+          name="named"
+          label="Name"
+          sx={{ width: "50%" }}
+          value={npcData.named}
+          onChange={handleChange} // Call handleChange on input change
+        />
+        <TextField
+          margin="dense"
+          size="small"
+          name="role"
+          label="Role"
+          sx={{ width: "50%" }}
+          value={npcData.role}
+          onChange={handleChange} // Call handleChange on input change
+        />
+        <TextField
+          margin="dense"
+          size="small"
+          name="personality"
+          label="Personality"
+          fullWidth
+          value={npcData.personality}
+          onChange={handleChange} // Call handleChange on input change
+        />
+        <TextField
+          margin="dense"
+          name="likes"
+          label="Likes"
+          fullWidth
+          value={npcData.likes}
+          onChange={handleChange} // Call handleChange on input change
+        />
+        <TextField
+          margin="dense"
+          name="inventory"
+          label="Inventory"
+          fullWidth
+          value={npcData.inventory}
+          onChange={handleChange} // Call handleChange on input change
+        />
+        <TextField
+          margin="dense"
+          size="small"
+          name="money"
+          label="Money"
+          fullWidth
+          value={npcData.money}
+          onChange={handleChange} // Call handleChange on input change
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" color="secondary" onClick={handleCloseDialog}> 
+          {" "} Cancel{" "} {/* Cancel button to close the dialog */}
+        </Button>
+        <Button variant="outlined" color="primary" onClick={saveNpc}>
+          {action === "add" ? "Add" : "Edit"} {/* Show "Add" or "Edit" depending on the action */}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/app/npc/page.jsx
+++ b/app/npc/page.jsx
@@ -1,0 +1,205 @@
+"use client";
+
+// Import necessary Material UI components for layout and UI elements
+import { Box, Button, Container, IconButton, Paper } from "@mui/material";
+
+// Import icons for actions like editing and deleting
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import WhatshotIcon from '@mui/icons-material/Whatshot';
+import AddCircleIcon from '@mui/icons-material/AddCircle';
+
+// Import DataGrid component for displaying data in a table
+import { DataGrid } from "@mui/x-data-grid";
+
+// Import custom components for dialogs and alerts
+import NpcDialog from "./components/npc-dialog";
+import Alerts from "../components/alerts";
+
+// React hooks for state management
+import { useState, useEffect } from "react";
+
+// Axios for making HTTP requests to the backend
+import axios from "axios";
+
+export default function Npcs() {
+  // Define columns for the DataGrid table
+  const columns = [
+    { field: "_id", headerName: "ID", width: 10 },
+    { field: "named", headerName: "Name", flex: 1 },
+    { field: "role", headerName: "Role", flex: 0.5 },
+    { field: "personality", headerName: "Personality", flex: 1 },
+    { field: "likes", headerName: "Likes", flex: 1 },
+    { field: "inventory", headerName: "Inventory", flex: 1 },
+    { field: "money", headerName: "Money", flex: 1 },
+    // Commented out extra field
+    // { field: "extra", headerName: "Extra", flex: 1 },
+    {
+      field: "actions",
+      headerName: "",
+      width: 100,
+      renderCell: (params) => (
+        <Box>
+          {/* Edit button */}
+          <IconButton
+            color="primary"
+            onClick={() => handleNpc({ action: "edit", npcData: params.row })}
+          >
+            <AutoFixHighIcon />
+          </IconButton>
+          {/* Delete button */}
+          <IconButton
+            color="secondary"
+            onClick={() => deleteNpc(params.row._id)}
+          >
+            <WhatshotIcon /> {/* Change icon color to red */}
+          </IconButton>
+        </Box>
+      ),
+    },
+  ];
+
+  // State variables to manage data and UI states
+  const [action, setAction] = useState(""); // Action (edit, add)
+  const [openDialog, setOpenDialog] = useState(false); // Open dialog state
+  const [rows, setRows] = useState(); // Rows for DataGrid
+  const [openAlert, setOpenAlert] = useState(false); // Open alert state
+  const [alert, setAlert] = useState({
+    message: "",
+    severity: "",
+  }); // Alert message and severity (error, success)
+  const [npcData, setNpc] = useState({
+    id: null,
+    named: "",
+    role: "",
+    personality: "",
+    inventory: "",
+    likes: "",
+    money: "",
+    // extra: ""
+  }); // Npc data to be added or edited
+
+  // Fetch the npcs from the server when the component is mounted
+  useEffect(() => {
+    fetchNpcs();
+  }, []); // Empty dependency array means it runs only once when the component mounts
+
+  // Fetch the list of npcs from the backend
+  const fetchNpcs = async () => {
+    try {
+      const response = await axios.get("http://127.0.0.1:5000/api/v1/npcs");
+      setRows(response.data); // Set the fetched npcs to the state
+    } catch (error) {
+      console.error("Error fetching npcs", error);
+      // Display an alert if there is an error
+      setAlert({
+        message: "Failed to load npcs",
+        severity: "error",
+      });
+      setOpenAlert(true); // Open the alert
+    }
+  };
+
+  // Handle the npc actions (add or edit)
+  const handleNpc = ({ action, npcData }) => {
+    console.info("Handle npc action:", action);
+    setAction(action); // Set the current action (add/edit)
+    setOpenDialog(true); // Open the dialog
+    // If adding a npc, clear the form fields
+    if (action === "add") {
+      setNpc({
+        id: null,
+        named: "",
+        role: "",
+        personality: "",
+        inventory: "",
+        likes: "",
+        money: "",
+        // extra: ""
+      });
+    } else if (action === "edit") {
+      setNpc(npcData); // If editing, load the npc data into the form
+    } else {
+      console.warn("Unknown action:", action);
+    }
+  };
+
+  // Delete a npc from the database
+  const deleteNpc = async (id) => {
+    try {
+      await axios.delete(`http://127.0.0.1:5000/api/v1/npcs/${id}`);
+      setRows(rows.filter((row) => row._id !== id)); // Remove the deleted npc from the table
+      setAlert({
+        message: "Npc deleted successfully",
+        severity: "success",
+      });
+    } catch (error) {
+      console.error("Error deleting npc: ", error);
+      setAlert({
+        message: "Failed to delete npc",
+        severity: "error",
+      });
+    }
+    setOpenAlert(true); // Open the alert with success or error message
+  };
+
+  return (
+    <Container maxWidth="xl" disableGutters>
+      {/* Button to add a new npc */}
+      <Box sx={{ display: "flex", justifyContent: "center", mb: 2, mt: 2 }}>
+        <Button
+          startIcon={<AddCircleIcon />}
+          variant="contained"
+          sx={{ borderRadius: 3 }}
+          onClick={() => handleNpc({ action: "add" })}
+        >
+          Add NPC
+        </Button>
+      </Box>
+
+      {/* DataGrid table for displaying npcs */}
+      <Paper
+        sx={{
+          padding: 2,
+          borderRadius: 2,
+          maxWidth: "80%",
+          margin: "0 auto",
+          height: "400px",
+        }}
+      >
+        <DataGrid
+          columns={columns} // Columns to display
+          rows={rows} // Data to populate the table
+          getRowId={(row) => row._id} // Unique ID for each row
+          initialState={{
+            pagination: {
+              paginationModel: { page: 0, pageSize: 5 },
+            },
+          }}
+          pageSizeOptions={[5, 10]} // Page size options for pagination
+         
+        />
+      </Paper>
+
+      {/* Dialog for adding or editing a npc */}
+      <NpcDialog
+        open={openDialog}
+        setOpen={setOpenDialog}
+        npcData={npcData}
+        setNpc={setNpc}
+        action={action}
+        rows={rows}
+        setRows={setRows}
+        setAlert={setAlert}
+        setOpenAlert={setOpenAlert}
+      />
+
+      {/* Alert component to show error or success messages */}
+      <Alerts
+        open={openAlert}
+        setOpen={setOpenAlert}
+        alert={alert}
+        setAlert={setAlert}
+      />
+    </Container>
+  );
+}


### PR DESCRIPTION
## What?
Added npc page and dialog

## Why?
To display NPCs stored in the database

## How?
I used a datagrid on page.jsx to ensure full CRUD functionality. I also created a dialog component to create and update NPCs

## Testing?
I have run the app.py and the nextjs app to test CRUD operations. It is important to set environment varibles

## Screenshots
![image](https://github.com/user-attachments/assets/97b9d229-9505-4d7d-920e-bf69c9dd8792)
![image](https://github.com/user-attachments/assets/a9607d29-3f40-43c9-a3f8-0faa7f64a9fa)
![image](https://github.com/user-attachments/assets/48705a65-7063-4de3-a70f-eb34cc0e3242)

## Anything Else?
Further Card implementation would remarkably improve UX