### PR TITLE
hotfix(npc-page): deleted repeated error message

### DIFF
--- a/app/npc/components/npc-dialog.jsx
+++ b/app/npc/components/npc-dialog.jsx
@@ -37,7 +37,7 @@ export default function NpcDialog({
           severity: "success", // Set the message severity as success
         });
       } catch (error) {
-        console.error("Error adding npc: ", error);
+        //console.error("Error adding npc: ", error);
         setAlert({
           message: "Failed to add NPC", // Error message
           severity: "error", // Set the message severity as error

--- a/app/npc/page.jsx
+++ b/app/npc/page.jsx
@@ -89,7 +89,7 @@ export default function Npcs() {
       const response = await axios.get("http://127.0.0.1:5000/api/v1/npcs");
       setRows(response.data); // Set the fetched npcs to the state
     } catch (error) {
-      console.error("Error fetching npcs", error);
+      //console.error("Error fetching npcs", error);
       // Display an alert if there is an error
       setAlert({
         message: "Failed to load npcs",
@@ -101,7 +101,7 @@ export default function Npcs() {
 
   // Handle the npc actions (add or edit)
   const handleNpc = ({ action, npcData }) => {
-    console.info("Handle npc action:", action);
+    //console.info("Handle npc action:", action);
     setAction(action); // Set the current action (add/edit)
     setOpenDialog(true); // Open the dialog
     // If adding a npc, clear the form fields
@@ -119,7 +119,7 @@ export default function Npcs() {
     } else if (action === "edit") {
       setNpc(npcData); // If editing, load the npc data into the form
     } else {
-      console.warn("Unknown action:", action);
+      //console.warn("Unknown action:", action);
     }
   };
 
@@ -133,7 +133,7 @@ export default function Npcs() {
         severity: "success",
       });
     } catch (error) {
-      console.error("Error deleting npc: ", error);
+      //console.error("Error deleting npc: ", error);
       setAlert({
         message: "Failed to delete npc",
         severity: "error",


### PR DESCRIPTION
## What?
Removed console error messages

## Why?
Error messages for the user are already functional using snackbars

## How?
I commented the console error message lines of code on dialog and page from NPC

## Testing?
I ran the app, tried to add an empty NPC and verified that it only shows the snackbar message
## Screenshots
Before:
![image](https://github.com/user-attachments/assets/41904e16-1ff3-4701-be13-2a5f89bb8770)
After:
![image](https://github.com/user-attachments/assets/320e8277-4b6b-4043-9c06-682a5775bf3c)