### PR TITLE
feat(banner): add banner to pages

### DIFF
--- a/app/bosses/page.jsx
+++ b/app/bosses/page.jsx
@@ -1,5 +1,8 @@
 "use client";
+
+import { useRouter } from "next/navigation";
 import { Box, Button, Card, CardActions, CardMedia, Container, IconButton, Slide, Typography } from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack"; // Import the back arrow icon
 import Grid from "@mui/material/Grid2";
 import CardContent from '@mui/material/CardContent';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
@@ -11,7 +14,12 @@ import { useState, useEffect } from "react";
 import axios from "axios";
 import { darkTheme } from "../styles/global-theme";
 
+
+
 export default function Bosses() {
+  // State for back to homepage.
+  const router = useRouter();
+
   // State for tracking the current action (add, edit, view)
   const [action, setAction] = useState("");
 
@@ -33,6 +41,11 @@ export default function Bosses() {
   // State for tracking which items are visible
   const [visible, setVisible] = useState([]);
 
+  //To homepage
+  const handleBack = () => {
+    router.push("/"); // to homepage
+  };
+  
   // Function to handle mouse enter event
   const handleMouseEnter = () => {
     // Play hover sound effect
@@ -45,6 +58,7 @@ export default function Bosses() {
     const sound = new Audio("/SFX/click_ufo.mp3");
     sound.play().catch(error => console.log("Sound playback error: ", error)); // Catch any playback errors
   }
+
 
   // State for storing individual Boss data
   const [bossData, setBoss] = useState({
@@ -114,16 +128,61 @@ export default function Bosses() {
 
   return (
     <Container maxWidth="xl" disableGutters>
-      <Box sx={{ display: "flex", justifyContent: "center", mb: 2, mt: 2 }}>
-        <Button
-          startIcon={<AddCircleIcon />}
-          variant="contained"
-          sx={{ borderRadius: 3 }}
-          onClick={() => handleBoss({ action: "add", bossData: {} })} // Handle adding a new Boss
-        >
-          Add Boss
-        </Button>
-      </Box>
+    <Box sx={{display: "flex", flexDirection: "column", alignItems: "center", mb: 2, mt: 2,}}>
+
+      {/* Button to Home*/}
+      <Button
+        onClick={handleBack}
+        variant="outlined"
+
+        sx={{
+          position: "absolute",
+          top: 90,
+          left: 30,
+          borderRadius: "50%",
+          width: 50,
+          height: 50,
+          minWidth: 0, 
+          padding: 0,
+        }}
+      >
+        <ArrowBackIcon />
+      </Button>
+
+      {/* Title */}
+      <Typography
+        variant="h3"
+        sx={{
+          position: "absolute",
+          top: "30%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+        }}
+      >
+        BOSSES 
+      </Typography>
+
+      {/* Banner */}
+      <img
+        src="/bannerPages.png"
+        alt="Banner"
+        style={{
+          width: "60%", // Ensures the image fits the container
+          objectFit: "cover", // Crops the image proportionally to fill the container
+        }}
+      />
+
+      {/*Button ADD*/}
+      <Button
+        startIcon={<AddCircleIcon />}
+        variant="contained"
+        sx={{ borderRadius: 3, mt: 2 }} // Adds margin-top to create space below the image
+        onClick={() => handleBoss({ action: "add", bossData: {} })} // Handle adding a new Boss
+      >
+        Add Boss
+      </Button>
+      
+    </Box>
       <Grid container spacing={4} justifyContent={"center"}>
         {bossCards.map((iterator, index) => (
           <Slide in={visible.includes(index)} direction="up" key={iterator._id} timeout={{ enter: 300 }}>

--- a/app/characters/page.jsx
+++ b/app/characters/page.jsx
@@ -1,8 +1,11 @@
 
   "use client";
+
+import { useRouter } from "next/navigation"; 
 import { Box, Button, Card, CardActions, CardMedia, Container, IconButton, Slide, Typography } from "@mui/material";
 import Grid from "@mui/material/Grid2";
 import CardContent from '@mui/material/CardContent';
+import ArrowBackIcon from "@mui/icons-material/ArrowBack"; // Import the back arrow icon
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import WhatshotIcon from '@mui/icons-material/Whatshot';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
@@ -13,6 +16,9 @@ import axios from "axios";
 import { darkTheme } from "../styles/global-theme";
 
 export default function Characters() {
+  // State for back to homepage.
+  const router = useRouter();
+
   // State for tracking the current action (add, edit, view)
   const [action, setAction] = useState("");
 
@@ -59,6 +65,11 @@ export default function Characters() {
     playerName: "",
     picture: "",
   });
+
+  //To homepage
+  const handleBack = () => {
+    router.push("/"); // to homepage
+  };
 
   // Fetch Character data when the component mounts
   useEffect(() => {
@@ -131,7 +142,51 @@ export default function Characters() {
 
   return (
     <Container maxWidth="xl" disableGutters>
-      <Box sx={{ display: "flex", justifyContent: "center", mb: 2, mt: 2 }}>
+    <Box sx={{display: "flex", flexDirection: "column", alignItems: "center", mb: 2, mt: 2,}}>
+
+        {/* Button to Home*/}
+        <Button
+          onClick={handleBack}
+          variant="outlined"
+
+          sx={{
+            position: "absolute",
+            top: 90,
+            left: 30,
+            borderRadius: "50%",
+            width: 50,
+            height: 50,
+            minWidth: 0, 
+            padding: 0,
+          }}
+        >
+          <ArrowBackIcon />
+        </Button>
+
+        {/* Title */}
+        <Typography
+          variant="h4"
+          sx={{
+            position: "absolute",
+            top: "30%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+          }}
+        >
+          CHARACTERS 
+        </Typography>
+
+        {/* Banner */}
+        <img
+          src="/bannerPages.png"
+          alt="Banner"
+          style={{
+            width: "60%", // Ensures the image fits the container
+            objectFit: "cover", // Crops the image proportionally to fill the container
+          }}
+        />
+
+        {/*Button ADD*/}
         <Button
           startIcon={<AddCircleIcon />}
           variant="contained"

--- a/app/classes/page.jsx
+++ b/app/classes/page.jsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { useRouter } from "next/navigation"; 
+
 // Import necessary Material UI components for layout and UI elements
-import { Box, Button, Container, IconButton, Paper } from "@mui/material";
+import { Box, Button, Container, IconButton, Paper, Typography } from "@mui/material";
 
 // Import icons for actions like editing and deleting
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import ArrowBackIcon from "@mui/icons-material/ArrowBack"; // Import the back arrow icon
 import WhatshotIcon from '@mui/icons-material/Whatshot';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 
@@ -22,6 +25,8 @@ import { useState, useEffect } from "react";
 import axios from "axios";
 
 export default function Classes() {
+  const router = useRouter();
+
   // Define columns for the DataGrid table
   // Each column has an appropriate width and flex to make it look aesthetic
   const columns = [
@@ -194,6 +199,11 @@ export default function Classes() {
     awp: "",
   }); // Class data to be added or edited
 
+  //To homepage
+  const handleBack = () => {
+    router.push("/"); // to homepage
+  };
+
   // Fetch the classes from the server when the component is mounted
   useEffect(() => {
     fetchClasses();
@@ -277,9 +287,52 @@ export default function Classes() {
   return (
     <Box sx={{ minHeight: '100vh', paddingBottom: '50px' }}> {/* Add a blank space in the bottom */}
       <Container maxWidth="xl" disableGutters>
-        {/* Button to add a new class */}
-        <Box sx={{ display: "flex", justifyContent: "center", mb: 2, mt: 2 }}>
-          <Button
+        <Box sx={{display: "flex", flexDirection: "column", alignItems: "center", mb: 2, mt: 2,}}>
+        
+        {/* Button to Home*/}
+        <Button
+          onClick={handleBack}
+          variant="outlined"
+
+          sx={{
+            position: "absolute",
+            top: 90,
+            left: 30,
+            borderRadius: "50%",
+            width: 50,
+            height: 50,
+            minWidth: 0, 
+            padding: 0,
+          }}
+        >
+          <ArrowBackIcon />
+        </Button>
+
+        {/* Title */}
+        <Typography
+          variant="h3"
+          sx={{
+            position: "absolute",
+            top: "30%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+          }}
+        >
+          CLASSES
+        </Typography>
+
+        {/* Banner */}
+        <img
+          src="/bannerPages.png"
+          alt="Banner"
+          style={{
+            width: "60%", // Ensures the image fits the container
+            objectFit: "cover", // Crops the image proportionally to fill the container
+          }}
+        />
+
+        {/*Button ADD*/}
+        <Button
             startIcon={<AddCircleIcon />}
             variant="contained"
             sx={{ borderRadius: 3 }}

--- a/app/npcs/page.jsx
+++ b/app/npcs/page.jsx
@@ -1,9 +1,13 @@
 "use client";
+import { useRouter } from "next/navigation"; 
+
 import { Box, Button, Card, CardActions, CardMedia, Container, IconButton, Slide, Typography } from "@mui/material";
 import Grid from "@mui/material/Grid2";
 import CardContent from '@mui/material/CardContent';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import WhatshotIcon from '@mui/icons-material/Whatshot';
+import ArrowBackIcon from "@mui/icons-material/ArrowBack"; // Import the back arrow icon
+
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import Alerts from "../components/alerts";
 import NpcDialog from "./components/npc-dialog";
@@ -12,6 +16,8 @@ import axios from "axios";
 import { darkTheme } from "../styles/global-theme";
 
 export default function Npcs() {
+  const router = useRouter();
+
   // State for tracking the current action (add, edit, view)
   const [action, setAction] = useState("");
 
@@ -58,6 +64,11 @@ export default function Npcs() {
     money: "",
     backstory: "",
   });
+
+    //To homepage
+    const handleBack = () => {
+      router.push("/"); // to homepage
+    };
 
   // Fetch NPC data when the component mounts
   useEffect(() => {
@@ -114,16 +125,61 @@ export default function Npcs() {
 
   return (
     <Container maxWidth="xl" disableGutters>
-      <Box sx={{ display: "flex", justifyContent: "center", mb: 2, mt: 2 }}>
+        {/* Button to add a new class */}
+        <Box sx={{display: "flex", flexDirection: "column", alignItems: "center", mb: 2, mt: 2,}}>
+
+        {/* Button to Home*/}
         <Button
-          startIcon={<AddCircleIcon />}
-          variant="contained"
-          sx={{ borderRadius: 3 }}
-          onClick={() => handleNpc({ action: "add", npcData: {} })} // Handle adding a new NPC
+          onClick={handleBack}
+          variant="outlined"
+
+          sx={{
+            position: "absolute",
+            top: 90,
+            left: 30,
+            borderRadius: "50%",
+            width: 50,
+            height: 50,
+            minWidth: 0, 
+            padding: 0,
+          }}
         >
-          Add NPC
-        </Button>
-      </Box>
+          <ArrowBackIcon />
+        </Button>        
+
+        {/* Title */}
+        <Typography
+          variant="h2"
+          sx={{
+            position: "absolute",
+            top: "30%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+          }}
+        >
+          NPCS
+        </Typography>
+
+        {/* Banner */}
+        <img
+          src="/bannerPages.png"
+          alt="Banner"
+          style={{
+            width: "60%", // Ensures the image fits the container
+            objectFit: "cover", // Crops the image proportionally to fill the container
+          }}
+        />
+
+        {/*Button ADD*/}
+      <Button
+        startIcon={<AddCircleIcon />}
+        variant="contained"
+        sx={{ borderRadius: 3, mt: 2 }} // Adds margin-top to create space below the image
+        onClick={() => handleNpc({ action: "add", npcData: {} })} // Handle adding a new NPC
+      >
+        Add NPC
+      </Button>
+    </Box>
       <Grid container spacing={4} justifyContent={"center"}>
         {npcCards.map((iterator, index) => (
           <Slide in={visible.includes(index)} direction="up" key={iterator._id} timeout={{ enter: 300 }}>

--- a/app/weapons/page.jsx
+++ b/app/weapons/page.jsx
@@ -1,12 +1,15 @@
 "use client";
 
+import { useRouter } from "next/navigation"; 
+
 // Import necessary Material UI components for layout and UI elements
-import { Box, Button, Container, IconButton, Paper } from "@mui/material";
+import { Box, Button, Container, IconButton, Paper, Typography } from "@mui/material";
 
 // Import icons for actions like editing and deleting
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import WhatshotIcon from '@mui/icons-material/Whatshot';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
+import ArrowBackIcon from "@mui/icons-material/ArrowBack"; // Import the back arrow icon
 
 // Import DataGrid component for displaying data in a table
 import { DataGrid } from "@mui/x-data-grid";
@@ -22,6 +25,8 @@ import { useState, useEffect } from "react";
 import axios from "axios";
 
 export default function Weapons() {
+  const router = useRouter();
+
   // Define columns for the DataGrid table
   const columns = [
     { field: "_id", headerName: "ID", width: 30 },
@@ -79,6 +84,11 @@ export default function Weapons() {
     weight: "",
     // extra: ""
   }); // Weapon data to be added or edited
+
+    //To homepage
+    const handleBack = () => {
+      router.push("/"); // to homepage
+    };
 
   // Fetch the weapons from the server when the component is mounted
   useEffect(() => {
@@ -148,8 +158,53 @@ export default function Weapons() {
   return (
     <Container maxWidth="xl" disableGutters>
       {/* Button to add a new weapon */}
-      <Box sx={{ display: "flex", justifyContent: "center", mb: 2, mt: 2 }}>
+        {/* Button to add a new class */}
+        <Box sx={{display: "flex", flexDirection: "column", alignItems: "center", mb: 2, mt: 2,}}>
+        
+        {/* Button to Home*/}
         <Button
+          onClick={handleBack}
+          variant="outlined"
+
+          sx={{
+            position: "absolute",
+            top: 90,
+            left: 30,
+            borderRadius: "50%",
+            width: 50,
+            height: 50,
+            minWidth: 0, 
+            padding: 0,
+          }}
+        >
+          <ArrowBackIcon />
+        </Button>
+
+        {/* Title */}
+        <Typography
+          variant="h4"
+          sx={{
+            position: "absolute",
+            top: "30%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+          }}
+        >
+          WEAPONS
+        </Typography>
+
+        {/* Banner */}
+        <img
+          src="/bannerPages.png"
+          alt="Banner"
+          style={{
+            width: "60%", // Ensures the image fits the container
+            objectFit: "cover", // Crops the image proportionally to fill the container
+          }}
+        />
+
+      {/*Button ADD*/}    
+      <Button
           startIcon={<AddCircleIcon />}
           variant="contained"
           sx={{ borderRadius: 3 }}


### PR DESCRIPTION
### What?
Add banner to pages, and include buttons to navigate back to the homepage.

### Why?
To improve the user experience by providing clear navigation and enhancing the visual appearance of the application.

### How?
•	Implemented banners for the homepage and individual pages.
•	Added circular buttons to the banner for navigating back to the homepage.

### Testing?
•	Manually tested the buttons to ensure they redirect to the homepage correctly.
•	Verified that banners are displayed properly on all pages.

### Screenshots (optional)
